### PR TITLE
Refuse to build the firmware if newlib has no long long type support

### DIFF
--- a/main.c
+++ b/main.c
@@ -60,6 +60,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "mist_cfg.h"
 #include "cdc_enumerate.h"
 
+#ifndef _WANT_IO_LONG_LONG
+#error "newlib lacks support of long long type in IO functions. Please use a toolchain that was compiled with option --enable-newlib-io-long-long."
+#endif
+
 const char version[] = {"$VER:ATH" VDATE};
 
 extern hdfTYPE hdf[2];


### PR DESCRIPTION
Because ```%llu``` is used in ```iprintf()``` now, newlib must support long long type.
That is newlib must be compiled with option ```--enable-newlib-io-long-long```, otherwise the output is strange or undefined.

It worked for me without long long type (no crashes, only strange output) and debug output can only be seen on serial output, but I think it makes sense to refuse to build the firmware without the required configuration of the toolchain.
